### PR TITLE
feat: generic memory skill detection in doctor

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -33,10 +33,10 @@ palaia doctor
 
 Review **every** warning before continuing. For each finding, ask the user explicitly:
 
-**smart-memory skill detected:**
-Tell the user: "I found an existing smart-memory installation. Palaia replaces it. Should I migrate your existing memories and then deactivate smart-memory?"
-- If yes: run `palaia migrate <workspace-path>`, then remove the smart-memory skill folder
-- If no: continue, but both systems will run in parallel (not recommended)
+**Memory skill(s) detected (e.g. smart-memory, context-store, recall-pro, …):**
+Tell the user: "I found [N] installed memory skill(s): [names]. Palaia replaces these. Should I migrate your existing memories and deactivate the old skill(s)?"
+- If yes: run `palaia migrate <workspace-path>` for each, then remove or archive the old skill folder(s)
+- If no: continue, but multiple memory systems running in parallel is not recommended
 
 **OpenClaw memory plugin still set to memory-core:**
 Tell the user: "Should I switch OpenClaw to use Palaia as the memory system?"

--- a/palaia/doctor.py
+++ b/palaia/doctor.py
@@ -145,25 +145,100 @@ def _check_openclaw_plugin() -> dict[str, Any]:
     }
 
 
-def _check_smart_memory_skill() -> dict[str, Any]:
-    """Check if smart-memory skill is still installed."""
-    skill_path = Path.home() / ".openclaw" / "workspace" / "skills" / "smart-memory"
+def _parse_skill_frontmatter(text: str) -> dict[str, str]:
+    """Parse YAML-like frontmatter from SKILL.md without requiring a yaml library.
 
-    if skill_path.exists() and skill_path.is_dir():
+    Returns dict with 'name' and 'description' keys (empty string if not found).
+    """
+    result: dict[str, str] = {"name": "", "description": ""}
+    # Match content between --- fences
+    m = re.match(r"^---\s*\n(.*?)\n---", text, re.DOTALL)
+    if not m:
+        return result
+
+    fm = m.group(1)
+    for key in ("name", "description"):
+        # Match 'key: value' or 'key: >\n  multi-line'
+        pattern = rf"^{key}:\s*(?:>\s*\n((?:[ \t]+.+\n?)+)|(.+))$"
+        km = re.search(pattern, fm, re.MULTILINE)
+        if km:
+            if km.group(1):
+                # Multi-line folded scalar — join indented lines
+                result[key] = " ".join(line.strip() for line in km.group(1).strip().splitlines())
+            else:
+                result[key] = km.group(2).strip().strip("\"'")
+    return result
+
+
+_MEMORY_KEYWORDS = re.compile(
+    r"memory|recall|remember|persist|storage|knowledge.?base|context|forget",
+    re.IGNORECASE,
+)
+
+
+def _check_memory_skills() -> dict[str, Any]:
+    """Scan installed OpenClaw skills for memory-related skills."""
+    skill_dirs = [
+        Path.home() / ".openclaw" / "workspace" / "skills",
+        Path("/home/linuxbrew/.linuxbrew/lib/node_modules/openclaw/skills"),
+        Path.home() / ".openclaw" / "skills",
+        Path.home() / ".local" / "share" / "openclaw" / "skills",
+    ]
+
+    found_skills: list[dict[str, str]] = []
+    seen_names: set[str] = set()
+
+    for base in skill_dirs:
+        if not base.is_dir():
+            continue
+        for child in sorted(base.iterdir()):
+            if not child.is_dir():
+                continue
+            skill_md = child / "SKILL.md"
+            if not skill_md.is_file():
+                continue
+            try:
+                content = skill_md.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+
+            meta = _parse_skill_frontmatter(content)
+            name = meta["name"] or child.name
+            desc = meta["description"]
+
+            # Skip Palaia itself
+            if name.lower() == "palaia":
+                continue
+
+            # Deduplicate by name
+            if name in seen_names:
+                continue
+
+            # Check for memory keywords in description
+            if desc and _MEMORY_KEYWORDS.search(desc):
+                seen_names.add(name)
+                found_skills.append({
+                    "name": name,
+                    "path": str(child),
+                    "description": desc[:120],
+                })
+
+    if found_skills:
+        names = ", ".join(s["name"] for s in found_skills)
         return {
-            "name": "smart_memory_skill",
-            "label": "Smart-Memory skill",
+            "name": "memory_skills",
+            "label": "Installed memory skills",
             "status": "warn",
-            "message": f"Detected: {skill_path}",
-            "fix": (f"Remove or archive after Palaia is verified working:\n  rm -rf {skill_path}"),
-            "details": {"path": str(skill_path)},
+            "message": f"Found {len(found_skills)} memory skill(s): {names}",
+            "fix": "Consider migrating to Palaia:\n  palaia migrate <workspace> --dry-run",
+            "details": {"skills": found_skills},
         }
 
     return {
-        "name": "smart_memory_skill",
-        "label": "Smart-Memory skill",
+        "name": "memory_skills",
+        "label": "Installed memory skills",
         "status": "ok",
-        "message": "Not installed (clean)",
+        "message": "No conflicting memory skills detected",
     }
 
 
@@ -298,7 +373,7 @@ def run_doctor(palaia_root: Path | None = None) -> list[dict[str, Any]]:
         _check_palaia_init(palaia_root),
         _check_embedding_chain(palaia_root),
         _check_openclaw_plugin(),
-        _check_smart_memory_skill(),
+        _check_memory_skills(),
         _check_legacy_memory_files(),
         _check_heartbeat_legacy(),
         _check_wal_health(palaia_root),

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -9,9 +9,9 @@ import pytest
 from palaia.doctor import (
     _check_embedding_chain,
     _check_heartbeat_legacy,
+    _check_memory_skills,
     _check_openclaw_plugin,
     _check_palaia_init,
-    _check_smart_memory_skill,
     _check_wal_health,
     format_doctor_report,
     run_doctor,
@@ -138,22 +138,50 @@ class TestCheckOpenClawPlugin:
         assert "fix" in result
 
 
-class TestCheckSmartMemorySkill:
-    def test_not_installed(self, tmp_path, monkeypatch):
+class TestCheckMemorySkills:
+    def test_no_skills_found(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HOME", str(tmp_path))
-        result = _check_smart_memory_skill()
+        result = _check_memory_skills()
         assert result["status"] == "ok"
-        assert "Not installed" in result["message"]
+        assert result["name"] == "memory_skills"
+        assert "No conflicting" in result["message"]
 
-    def test_installed(self, tmp_path, monkeypatch):
+    def test_detects_memory_skill(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HOME", str(tmp_path))
         skill_dir = tmp_path / ".openclaw" / "workspace" / "skills" / "smart-memory"
         skill_dir.mkdir(parents=True)
-        (skill_dir / "SKILL.md").write_text("# Smart Memory")
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: smart-memory\ndescription: 5-layer memory architecture for OpenClaw agents.\n---\n# Smart Memory\n"
+        )
 
-        result = _check_smart_memory_skill()
+        result = _check_memory_skills()
         assert result["status"] == "warn"
-        assert "Detected" in result["message"]
+        assert "smart-memory" in result["message"]
+        assert len(result["details"]["skills"]) == 1
+        assert result["details"]["skills"][0]["name"] == "smart-memory"
+
+    def test_palaia_excluded(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        skill_dir = tmp_path / ".openclaw" / "workspace" / "skills" / "palaia"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: palaia\ndescription: Local persistent memory for OpenClaw agents.\n---\n# Palaia\n"
+        )
+
+        result = _check_memory_skills()
+        assert result["status"] == "ok"
+        assert "No conflicting" in result["message"]
+
+    def test_non_memory_skill_ignored(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        skill_dir = tmp_path / ".openclaw" / "workspace" / "skills" / "weather"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: weather\ndescription: Get current weather and forecasts.\n---\n# Weather\n"
+        )
+
+        result = _check_memory_skills()
+        assert result["status"] == "ok"
 
 
 class TestCheckHeartbeatLegacy:
@@ -291,7 +319,9 @@ class TestDoctorCLI:
         # Create a smart-memory skill to trigger a warning
         skill_dir = tmp_path / ".openclaw" / "workspace" / "skills" / "smart-memory"
         skill_dir.mkdir(parents=True)
-        (skill_dir / "SKILL.md").write_text("# Smart Memory")
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: smart-memory\ndescription: 5-layer memory architecture for OpenClaw agents.\n---\n"
+        )
 
         import io
         import sys


### PR DESCRIPTION
## Summary

Replace hardcoded `_check_smart_memory_skill()` with generic `_check_memory_skills()` scanner that detects **any** installed OpenClaw skill with memory-related keywords — not just smart-memory.

## Changes

### `palaia/doctor.py`
- New `_parse_skill_frontmatter()` — parses YAML frontmatter from SKILL.md without requiring `yaml` package (uses regex)
- New `_check_memory_skills()` — scans all standard OpenClaw skill directories:
  - `~/.openclaw/workspace/skills/`
  - `/home/linuxbrew/.linuxbrew/lib/node_modules/openclaw/skills/`
  - `~/.openclaw/skills/`
  - `~/.local/share/openclaw/skills/`
- Detects skills with memory keywords in description: `memory`, `recall`, `remember`, `persist`, `storage`, `knowledge base`, `context`, `forget`
- Excludes Palaia itself from detection
- Removed old `_check_smart_memory_skill()`

### `SKILL.md`
- Step 2 now references generic memory skill detection instead of hardcoded smart-memory

### `tests/test_doctor.py`
- Replaced `TestCheckSmartMemorySkill` with `TestCheckMemorySkills`
- Tests: no skills found (ok), memory skill detected (warn), palaia excluded, non-memory skill ignored
- All 27 tests pass