### PR TITLE
fix: resolve 14 ruff lint errors

### DIFF
--- a/palaia/cli.py
+++ b/palaia/cli.py
@@ -83,15 +83,15 @@ def cmd_init(args):
         if store_mode == "isolated":
             config["store_mode"] = "isolated"
             print(f"🤖 Found {len(agents)} agents: {', '.join(agents)}")
-            print(f"   Using isolated stores — each agent gets its own .palaia directory.")
+            print("   Using isolated stores — each agent gets its own .palaia directory.")
         else:
             config["store_mode"] = "shared"
             print(f"🤖 Found {len(agents)} agents: {', '.join(agents)}")
             print(f"   Using shared store at {target}")
-            print(f"   All agents will see team-scoped entries.")
-            print(f"   Use --agent flag when writing so entries are attributed correctly.")
+            print("   All agents will see team-scoped entries.")
+            print("   Use --agent flag when writing so entries are attributed correctly.")
             if store_mode is None:
-                print(f"   (Use 'palaia init --isolated' for separate stores per agent)")
+                print("   (Use 'palaia init --isolated' for separate stores per agent)")
     elif len(agents) == 1:
         print(f"🤖 Found 1 agent: {agents[0]}")
         config["store_mode"] = "shared"
@@ -100,7 +100,16 @@ def cmd_init(args):
     save_config(target, config)
 
     if not is_reinit:
-        if _json_out({"status": "created", "path": str(target), "embedding_chain": chain, "agents": agents, "store_mode": config.get("store_mode", "shared")}, args):
+        if _json_out(
+            {
+                "status": "created",
+                "path": str(target),
+                "embedding_chain": chain,
+                "agents": agents,
+                "store_mode": config.get("store_mode", "shared"),
+            },
+            args,
+        ):
             return 0
         print(f"Initialized Palaia at {target}")
 
@@ -1421,8 +1430,13 @@ def main():
     p_init = sub.add_parser("init", help="Initialize .palaia directory")
     p_init.add_argument("--path", default=None, help="Target directory")
     p_init.add_argument("--json", action="store_true", help="Output as JSON")
-    p_init.add_argument("--isolated", action="store_const", const="isolated", dest="store_mode",
-                        help="Use isolated stores per agent (default: shared)")
+    p_init.add_argument(
+        "--isolated",
+        action="store_const",
+        const="isolated",
+        dest="store_mode",
+        help="Use isolated stores per agent (default: shared)",
+    )
 
     # write
     p_write = sub.add_parser("write", help="Write a memory entry")
@@ -1445,7 +1459,9 @@ def main():
     p_query.add_argument("--json", action="store_true", help="Output as JSON")
 
     # ingest
-    p_ingest = sub.add_parser("ingest", help="Ingest documents for RAG search (creates a copy; source files are NOT modified or deleted)")
+    p_ingest = sub.add_parser(
+        "ingest", help="Ingest documents for RAG search (creates a copy; source files are NOT modified or deleted)"
+    )
     p_ingest.add_argument("source", help="File path, URL, or directory to ingest")
     p_ingest.add_argument("--project", default=None, help="Assign to project")
     p_ingest.add_argument("--scope", default=None, help="Scope (default: private)")
@@ -1536,18 +1552,15 @@ def main():
     p_memo_send = memo_sub.add_parser("send", help="Send a memo to an agent")
     p_memo_send.add_argument("to", help="Recipient agent name")
     p_memo_send.add_argument("message", help="Message body")
-    p_memo_send.add_argument("--priority", default="normal", choices=["normal", "high"],
-                             help="Priority level")
+    p_memo_send.add_argument("--priority", default="normal", choices=["normal", "high"], help="Priority level")
     p_memo_send.add_argument("--ttl-hours", type=int, default=72, help="TTL in hours (default: 72)")
     p_memo_send.add_argument("--agent", default=None, help="Sender agent name")
     p_memo_send.add_argument("--json", action="store_true", help="Output as JSON")
 
     p_memo_broadcast = memo_sub.add_parser("broadcast", help="Broadcast memo to all agents")
     p_memo_broadcast.add_argument("message", help="Message body")
-    p_memo_broadcast.add_argument("--priority", default="normal", choices=["normal", "high"],
-                                  help="Priority level")
-    p_memo_broadcast.add_argument("--ttl-hours", type=int, default=72,
-                                  help="TTL in hours (default: 72)")
+    p_memo_broadcast.add_argument("--priority", default="normal", choices=["normal", "high"], help="Priority level")
+    p_memo_broadcast.add_argument("--ttl-hours", type=int, default=72, help="TTL in hours (default: 72)")
     p_memo_broadcast.add_argument("--agent", default=None, help="Sender agent name")
     p_memo_broadcast.add_argument("--json", action="store_true", help="Output as JSON")
 
@@ -1567,10 +1580,13 @@ def main():
 
     # lock — first positional is action_or_project (allows "palaia lock <project>" shorthand)
     p_lock = sub.add_parser("lock", help="Manage project locks")
-    p_lock.add_argument("action_or_project", nargs="?", default=None,
-                        help="Subcommand (status|renew|break|list) or project name for acquire shorthand")
-    p_lock.add_argument("project", nargs="?", default=None,
-                        help="Project name (for status/renew/break subcommands)")
+    p_lock.add_argument(
+        "action_or_project",
+        nargs="?",
+        default=None,
+        help="Subcommand (status|renew|break|list) or project name for acquire shorthand",
+    )
+    p_lock.add_argument("project", nargs="?", default=None, help="Project name (for status/renew/break subcommands)")
     p_lock.add_argument("--agent", default=None, help="Agent name")
     p_lock.add_argument("--reason", default="", help="Reason for locking")
     p_lock.add_argument("--ttl", type=int, default=None, help="TTL in seconds")

--- a/palaia/memo.py
+++ b/palaia/memo.py
@@ -38,9 +38,7 @@ def _parse_yaml_simple(text: str) -> dict:
             result[key] = None
         elif value.isdigit():
             result[key] = int(value)
-        elif (value.startswith('"') and value.endswith('"')) or (
-            value.startswith("'") and value.endswith("'")
-        ):
+        elif (value.startswith('"') and value.endswith('"')) or (value.startswith("'") and value.endswith("'")):
             result[key] = value[1:-1]
         else:
             result[key] = value
@@ -68,7 +66,7 @@ def _parse_memo(text: str) -> tuple[dict, str]:
     if not m:
         return {}, text.strip()
     meta = _parse_yaml_simple(m.group(1))
-    body = text[m.end():].strip()
+    body = text[m.end() :].strip()
     return meta, body
 
 
@@ -169,9 +167,7 @@ class MemoManager:
         """
         target = agent or _detect_agent()
         if not target:
-            raise ValueError(
-                "Agent name required. Use --agent flag or set PALAIA_AGENT env var."
-            )
+            raise ValueError("Agent name required. Use --agent flag or set PALAIA_AGENT env var.")
 
         now = datetime.now(timezone.utc)
         results = []

--- a/palaia/migrate.py
+++ b/palaia/migrate.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from palaia.entry import content_hash
 from palaia.store import Store
 
-
 # System files that agents read at runtime — must never be deleted after migration.
 SYSTEM_FILE_PATTERNS = {
     "CONTEXT.md",

--- a/palaia/search.py
+++ b/palaia/search.py
@@ -132,7 +132,14 @@ class SearchEngine:
         self.bm25.index(docs)
         return docs_with_meta
 
-    def search(self, query: str, top_k: int = 10, include_cold: bool = False, project: str | None = None, agent: str | None = None) -> list[dict]:
+    def search(
+        self,
+        query: str,
+        top_k: int = 10,
+        include_cold: bool = False,
+        project: str | None = None,
+        agent: str | None = None,
+    ) -> list[dict]:
         """Search memories using hybrid ranking (BM25 + embeddings when available)."""
         docs_with_meta = self.build_index(include_cold=include_cold, agent=agent)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,8 +2,6 @@
 
 import importlib
 
-import pytest
-
 
 def test_palaia_home_env_overrides_cwd(tmp_path, monkeypatch):
     """PALAIA_HOME env var should override CWD-based search."""
@@ -14,12 +12,11 @@ def test_palaia_home_env_overrides_cwd(tmp_path, monkeypatch):
 
     monkeypatch.setenv("PALAIA_HOME", str(store))
 
-    from palaia.config import find_palaia_root
-
     # Reload to pick up env change
     import palaia.config
-    importlib.reload(palaia.config)
     from palaia.config import find_palaia_root
+
+    importlib.reload(palaia.config)
 
     result = find_palaia_root(start="/tmp/nowhere")
     assert result == store
@@ -35,6 +32,7 @@ def test_palaia_home_parent_dir(tmp_path, monkeypatch):
     monkeypatch.setenv("PALAIA_HOME", str(parent))
 
     import palaia.config
+
     importlib.reload(palaia.config)
     from palaia.config import find_palaia_root
 
@@ -52,6 +50,7 @@ def test_palaia_home_invalid_ignored(tmp_path, monkeypatch):
     (store / "config.json").write_text("{}")
 
     import palaia.config
+
     importlib.reload(palaia.config)
     from palaia.config import find_palaia_root
 

--- a/tests/test_memo.py
+++ b/tests/test_memo.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import json
-import os
 import time
-from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -96,7 +94,7 @@ def test_priority_sort_order(mm):
 def test_ttl_expiry(mm):
     """Expired memo does not appear in inbox."""
     # Send with 0 TTL (expires immediately)
-    meta = mm.send("elliot", "ephemeral", from_agent="cyberclaw", ttl_hours=0)
+    mm.send("elliot", "ephemeral", from_agent="cyberclaw", ttl_hours=0)
 
     # Need to wait a tiny bit for expiry
     time.sleep(0.01)
@@ -355,9 +353,8 @@ def test_cli_gc_json(palaia_root, capsys):
     """CLI memo gc --json returns valid JSON with stats."""
     import argparse
 
-    from palaia.cli import cmd_memo
-
     import palaia.cli
+    from palaia.cli import cmd_memo
 
     original_get_root = palaia.cli.get_root
     palaia.cli.get_root = lambda: palaia_root

--- a/tests/test_ux_improvements.py
+++ b/tests/test_ux_improvements.py
@@ -282,11 +282,7 @@ class TestListFilters:
         store.write("wrong tag", project="proj", tags=["weekly"], agent="bot1")
 
         entries = store.list_entries("hot")
-        filtered = [
-            (m, b)
-            for m, b in entries
-            if m.get("project") == "proj" and "daily" in (m.get("tags") or [])
-        ]
+        filtered = [(m, b) for m, b in entries if m.get("project") == "proj" and "daily" in (m.get("tags") or [])]
         assert len(filtered) == 1
 
     def test_cli_list_filters_json(self, palaia_root, pm):


### PR DESCRIPTION
Fixes CI failures introduced by PR #21 (memo).

### Changes
- Remove unused imports (`os`, `datetime`, `timedelta`, `timezone`, `pytest`)
- Fix import sorting (I001) in `migrate.py`, `test_config.py`, `test_memo.py`
- Remove unused variable assignment (`meta = mm.send()` → `mm.send()`)
- Remove extraneous f-string prefixes in `cli.py`
- Apply `ruff format` to all changed files

### Verification
- `ruff check palaia/ tests/` — all checks passed
- `pytest tests/ -x -q` — 314 passed, 0 failures