### PR TITLE
feat: Significance Tagging + Retrieval-Hit Decay (#33)

### DIFF
--- a/palaia/__init__.py
+++ b/palaia/__init__.py
@@ -4,5 +4,5 @@ Palaia — Local, cloud-free memory for OpenClaw agents.
 
 from __future__ import annotations
 
-__version__ = "1.9.0"
+__version__ = "1.10.0"
 __author__ = "byte5 GmbH"

--- a/palaia/cli.py
+++ b/palaia/cli.py
@@ -734,6 +734,9 @@ def cmd_write(args):
     instance = _resolve_instance_for_write(args)
 
     entry_type = getattr(args, "type", None)
+    significance_raw = getattr(args, "significance", None)
+    significance = significance_raw.split(",") if significance_raw else None
+
     entry_id = store.write(
         body=args.text,
         scope=args.scope,
@@ -747,6 +750,7 @@ def cmd_write(args):
         assignee=getattr(args, "assignee", None),
         due_date=getattr(args, "due_date", None),
         instance=instance,
+        significance=significance,
     )
 
     # Check if this was a dedup (existing entry returned)
@@ -820,6 +824,9 @@ def cmd_edit(args):
     # Scope enforcement: resolve agent from config (#39)
     agent = _resolve_agent(args)
 
+    significance_raw = getattr(args, "significance", None)
+    significance = significance_raw.split(",") if significance_raw else None
+
     try:
         meta = store.edit(
             entry_id=entry_id,
@@ -832,6 +839,7 @@ def cmd_edit(args):
             assignee=getattr(args, "assignee", None),
             due_date=getattr(args, "due_date", None),
             entry_type=getattr(args, "type", None),
+            significance=significance,
         )
     except (ValueError, PermissionError) as e:
         if _json_out({"error": str(e)}, args):
@@ -890,6 +898,7 @@ def cmd_query(args):
         priority=getattr(args, "priority", None),
         assignee=getattr(args, "assignee", None),
         instance=getattr(args, "instance", None),
+        significance=getattr(args, "significance", None),
     )
 
     if _json_out({"results": results}, args):
@@ -1141,6 +1150,7 @@ def cmd_list(args):
     priority_filter = getattr(args, "priority", None)
     assignee_filter = getattr(args, "assignee", None)
     instance_filter = getattr(args, "instance", None)
+    significance_filter = getattr(args, "significance", None)
 
     if project_filter:
         entries_with_tier = [(m, b, t) for m, b, t in entries_with_tier if m.get("project") == project_filter]
@@ -1163,6 +1173,12 @@ def cmd_list(args):
         entries_with_tier = [(m, b, t) for m, b, t in entries_with_tier if m.get("assignee") == assignee_filter]
     if instance_filter:
         entries_with_tier = [(m, b, t) for m, b, t in entries_with_tier if m.get("instance") == instance_filter]
+    if significance_filter:
+        entries_with_tier = [
+            (m, b, t)
+            for m, b, t in entries_with_tier
+            if significance_filter in (m.get("significance") or [])
+        ]
 
     if _json_out(
         {
@@ -1181,6 +1197,8 @@ def cmd_list(args):
                     "priority": meta.get("priority", ""),
                     "assignee": meta.get("assignee", ""),
                     "due_date": meta.get("due_date", ""),
+                    "significance": meta.get("significance", []),
+                    "recall_count": meta.get("recall_count", 0),
                     "tier": t,
                     "decay_score": meta.get("decay_score", 0),
                     "preview": body[:80].replace("\n", " "),
@@ -1201,32 +1219,59 @@ def cmd_list(args):
     print(section(f"Entries ({tier_label})"))
 
     rows = []
+    # Check if any entry has significance to decide column visibility
+    has_significance = any(meta.get("significance") for meta, _, _ in entries_with_tier)
     for meta, body, t in entries_with_tier:
         title = meta.get("title", "(untitled)")
         entry_id = meta.get("id", "?")[:8]
         scope = meta.get("scope", "team")
         age = relative_time(meta.get("created", ""))
+        sig_str = ",".join(meta.get("significance", [])) if meta.get("significance") else ""
         if list_all:
-            rows.append((entry_id, t, scope, title, age))
+            if has_significance:
+                rows.append((entry_id, t, scope, title, sig_str, age))
+            else:
+                rows.append((entry_id, t, scope, title, age))
         else:
-            rows.append((entry_id, scope, title, age))
+            if has_significance:
+                rows.append((entry_id, scope, title, sig_str, age))
+            else:
+                rows.append((entry_id, scope, title, age))
 
     if list_all:
-        print(
-            table_multi(
-                headers=("ID", "Tier", "Scope", "Title", "Age"),
-                rows=rows,
-                min_widths=(8, 4, 6, 16, 8),
+        if has_significance:
+            print(
+                table_multi(
+                    headers=("ID", "Tier", "Scope", "Title", "Significance", "Age"),
+                    rows=rows,
+                    min_widths=(8, 4, 6, 16, 12, 8),
+                )
             )
-        )
+        else:
+            print(
+                table_multi(
+                    headers=("ID", "Tier", "Scope", "Title", "Age"),
+                    rows=rows,
+                    min_widths=(8, 4, 6, 16, 8),
+                )
+            )
     else:
-        print(
-            table_multi(
-                headers=("ID", "Scope", "Title", "Age"),
-                rows=rows,
-                min_widths=(8, 6, 20, 8),
+        if has_significance:
+            print(
+                table_multi(
+                    headers=("ID", "Scope", "Title", "Significance", "Age"),
+                    rows=rows,
+                    min_widths=(8, 6, 20, 12, 8),
+                )
             )
-        )
+        else:
+            print(
+                table_multi(
+                    headers=("ID", "Scope", "Title", "Age"),
+                    rows=rows,
+                    min_widths=(8, 6, 20, 8),
+                )
+            )
 
     print(f"\n{len(entries_with_tier)} entries in {tier_label}.")
     return 0
@@ -1371,6 +1416,40 @@ def cmd_status(args):
 
     print(section("Embeddings"))
     print(table_kv(embed_rows))
+
+    # Top-5 most recalled entries (Issue #33)
+    recalled_entries = []
+    for tier_name in ("hot", "warm", "cold"):
+        tier_dir = root / tier_name
+        if not tier_dir.exists():
+            continue
+        for p in tier_dir.glob("*.md"):
+            try:
+                from palaia.entry import parse_entry as _pe2
+
+                text = p.read_text(encoding="utf-8")
+                meta, _ = _pe2(text)
+                rc = meta.get("recall_count", 0)
+                if rc > 0:
+                    recalled_entries.append(
+                        (rc, meta.get("id", "?")[:8], meta.get("title", "(untitled)"), tier_name)
+                    )
+            except Exception:
+                continue
+    if recalled_entries:
+        recalled_entries.sort(key=lambda x: x[0], reverse=True)
+        top_recalled = recalled_entries[:5]
+        print(section("Most Recalled"))
+        recall_rows = []
+        for rc, eid, title, tier_name in top_recalled:
+            recall_rows.append((eid, tier_name, str(rc), truncate(title, 40)))
+        print(
+            table_multi(
+                headers=("ID", "Tier", "Recalls", "Title"),
+                rows=recall_rows,
+                min_widths=(8, 4, 8, 20),
+            )
+        )
 
     # Index hint (warmup guidance)
     if info.get("index_hint"):
@@ -2708,6 +2787,11 @@ def main():
     p_write.add_argument("--assignee", default=None, help="Task assignee")
     p_write.add_argument("--due-date", default=None, dest="due_date", help="Task due date (ISO-8601)")
     p_write.add_argument("--instance", default=None, help="Session identity name")
+    p_write.add_argument(
+        "--significance",
+        default=None,
+        help="Comma-separated significance tags: decision,surprise,human,lesson,identity",
+    )
     p_write.add_argument("--json", action="store_true", help="Output as JSON")
 
     # edit
@@ -2726,6 +2810,11 @@ def main():
     )
     p_edit.add_argument("--assignee", default=None, help="Set task assignee")
     p_edit.add_argument("--due-date", default=None, dest="due_date", help="Set task due date (ISO-8601)")
+    p_edit.add_argument(
+        "--significance",
+        default=None,
+        help="Comma-separated significance tags: decision,surprise,human,lesson,identity",
+    )
     p_edit.add_argument("--json", action="store_true", help="Output as JSON")
 
     # query
@@ -2744,6 +2833,11 @@ def main():
     )
     p_query.add_argument("--assignee", default=None, help="Filter by assignee")
     p_query.add_argument("--instance", default=None, help="Filter by session identity")
+    p_query.add_argument(
+        "--significance",
+        default=None,
+        help="Filter by significance tag: decision|surprise|human|lesson|identity",
+    )
     p_query.add_argument("--rag", action="store_true", help="Output as RAG context block")
     p_query.add_argument("--json", action="store_true", help="Output as JSON")
 
@@ -2789,6 +2883,11 @@ def main():
     )
     p_list.add_argument("--assignee", default=None, help="Filter by assignee")
     p_list.add_argument("--instance", default=None, help="Filter by session identity")
+    p_list.add_argument(
+        "--significance",
+        default=None,
+        help="Filter by significance tag: decision|surprise|human|lesson|identity",
+    )
     p_list.add_argument("--json", action="store_true", help="Output as JSON")
 
     # status

--- a/palaia/decay.py
+++ b/palaia/decay.py
@@ -1,22 +1,63 @@
-"""Memory decay scoring and tier rotation (ADR-004)."""
+"""Memory decay scoring and tier rotation (ADR-004, Issue #33)."""
 
 from __future__ import annotations
 
 import math
 from datetime import datetime, timezone
 
+# Significance decay multipliers (Issue #33)
+# Higher = slower decay (multiplier on effective lambda denominator)
+SIGNIFICANCE_DECAY_BONUS: dict[str, float] = {
+    "decision": 3.0,
+    "identity": 3.0,
+    "human": 2.5,
+    "lesson": 2.0,
+    "surprise": 1.5,
+}
+
+
+def significance_multiplier(significance: list[str] | None) -> float:
+    """Calculate the combined significance decay multiplier.
+
+    Takes the maximum bonus from all significance tags.
+    Returns 1.0 if no significance tags are present (no bonus).
+    """
+    if not significance:
+        return 1.0
+    max_bonus = max(SIGNIFICANCE_DECAY_BONUS.get(tag, 1.0) for tag in significance)
+    return max_bonus
+
+
+def recall_multiplier(recall_count: int) -> float:
+    """Calculate recall-based decay multiplier.
+
+    Frequently recalled entries decay slower.
+    Uses log(1 + recall_count) to provide diminishing returns.
+    Returns >= 1.0 (1.0 = no bonus).
+    """
+    if recall_count <= 0:
+        return 1.0
+    return 1.0 + 0.3 * math.log(1 + recall_count)
+
 
 def decay_score(
     days_since_access: float,
     access_count: int = 1,
     lambda_val: float = 0.1,
+    significance: list[str] | None = None,
+    recall_count: int = 0,
 ) -> float:
     """Calculate decay score. Higher = more relevant.
 
     score = recency_factor * log(1 + access_count)
-    recency_factor = exp(-lambda * days_since_access)
+    recency_factor = exp(-lambda * days_since_access / sig_mult / recall_mult)
+
+    Significance tags and recall count slow down the decay rate.
     """
-    recency = math.exp(-lambda_val * days_since_access)
+    sig_mult = significance_multiplier(significance)
+    rec_mult = recall_multiplier(recall_count)
+    effective_lambda = lambda_val / (sig_mult * rec_mult)
+    recency = math.exp(-effective_lambda * days_since_access)
     frequency = math.log(1 + access_count)
     return round(recency * frequency, 6)
 

--- a/palaia/entry.py
+++ b/palaia/entry.py
@@ -18,6 +18,9 @@ DEFAULT_TYPE = "memory"
 VALID_STATUSES = {"open", "in-progress", "done", "wontfix"}
 VALID_PRIORITIES = {"critical", "high", "medium", "low"}
 
+# Significance tags (Issue #33)
+VALID_SIGNIFICANCE = {"decision", "surprise", "human", "lesson", "identity"}
+
 
 def _parse_yaml_simple(text: str) -> dict:
     """Minimal YAML-like parser for frontmatter. No dependency needed.
@@ -117,6 +120,22 @@ def validate_status(status: str | None) -> str | None:
     return status
 
 
+def validate_significance(significance: list[str] | None) -> list[str] | None:
+    """Validate significance tags. Returns validated list or None."""
+    if significance is None:
+        return None
+    validated = []
+    for tag in significance:
+        tag = tag.strip().lower()
+        if tag not in VALID_SIGNIFICANCE:
+            raise ValueError(
+                f"Invalid significance tag: '{tag}'. Valid: {', '.join(sorted(VALID_SIGNIFICANCE))}"
+            )
+        if tag not in validated:
+            validated.append(tag)
+    return validated if validated else None
+
+
 def validate_priority(priority: str | None) -> str | None:
     """Validate task priority."""
     if priority is None:
@@ -149,6 +168,7 @@ def create_entry(
     assignee: str | None = None,
     due_date: str | None = None,
     instance: str | None = None,
+    significance: list[str] | None = None,
 ) -> str:
     """Create a full memory entry string with frontmatter."""
     now = datetime.now(timezone.utc).isoformat()
@@ -172,6 +192,10 @@ def create_entry(
         meta["instance"] = resolved_instance
     if tags:
         meta["tags"] = tags
+    # Significance tags (Issue #33)
+    validated_sig = validate_significance(significance)
+    if validated_sig:
+        meta["significance"] = validated_sig
     # Auto-extract title from content if not explicitly provided
     effective_title = title if title else extract_title_from_content(body)
     if effective_title:

--- a/palaia/search.py
+++ b/palaia/search.py
@@ -172,6 +172,7 @@ class SearchEngine:
         priority: str | None = None,
         assignee: str | None = None,
         instance: str | None = None,
+        significance: str | None = None,
     ) -> list[dict]:
         """Search memories using hybrid ranking (BM25 + embeddings when available).
 
@@ -201,8 +202,14 @@ class SearchEngine:
             docs_with_meta = [
                 (did, text, meta) for did, text, meta in docs_with_meta if meta.get("instance") == instance
             ]
+        if significance:
+            docs_with_meta = [
+                (did, text, meta)
+                for did, text, meta in docs_with_meta
+                if significance in (meta.get("significance") or [])
+            ]
 
-        if project or entry_type or status or priority or assignee or instance:
+        if project or entry_type or status or priority or assignee or instance or significance:
             # Rebuild BM25 index with filtered docs
             self.bm25.index([(did, text) for did, text, meta in docs_with_meta])
 
@@ -264,12 +271,14 @@ class SearchEngine:
         # Sort by combined score
         ranked = sorted(combined.items(), key=lambda x: x[1], reverse=True)[:top_k]
 
-        # Build output
+        # Build output + retrieval-hit tracking (Issue #33)
         output = []
         for doc_id, score in ranked:
             entry = self.store.read(doc_id)
             if entry:
                 meta, body = entry
+                # Update recall tracking
+                self._track_recall(doc_id, meta, body)
                 result_entry = {
                     "id": doc_id,
                     "score": round(score, 4),
@@ -292,8 +301,30 @@ class SearchEngine:
                     result_entry["due_date"] = meta["due_date"]
                 if meta.get("instance"):
                     result_entry["instance"] = meta["instance"]
+                if meta.get("significance"):
+                    result_entry["significance"] = meta["significance"]
+                if meta.get("recall_count"):
+                    result_entry["recall_count"] = meta["recall_count"]
                 output.append(result_entry)
         return output
+
+    def _track_recall(self, entry_id: str, meta: dict, body: str) -> None:
+        """Update recall_count and last_recalled in entry frontmatter (Issue #33)."""
+        from datetime import datetime, timezone
+
+        from palaia.entry import serialize_entry
+
+        meta["recall_count"] = meta.get("recall_count", 0) + 1
+        meta["last_recalled"] = datetime.now(timezone.utc).isoformat()
+
+        new_text = serialize_entry(meta, body)
+        path = self.store._find_entry(entry_id)
+        if path:
+            relative = str(path.relative_to(self.store.root))
+            try:
+                self.store.write_raw(relative, new_text)
+            except OSError:
+                pass  # Non-critical — don't block query on write failure
 
     def _get_tier(self, entry_id: str) -> str:
         """Determine which tier an entry is in."""

--- a/palaia/store.py
+++ b/palaia/store.py
@@ -17,6 +17,7 @@ from palaia.entry import (
     update_access,
     validate_entry_type,
     validate_priority,
+    validate_significance,
     validate_status,
 )
 from palaia.index import EmbeddingCache
@@ -68,6 +69,7 @@ class Store:
         assignee: str | None = None,
         due_date: str | None = None,
         instance: str | None = None,
+        significance: list[str] | None = None,
     ) -> str:
         """Write a new memory entry. Returns the entry ID.
 
@@ -113,6 +115,7 @@ class Store:
             assignee=assignee,
             due_date=due_date,
             instance=instance,
+            significance=significance,
         )
         meta, _ = parse_entry(entry_text)
         entry_id = meta["id"]
@@ -152,6 +155,7 @@ class Store:
         assignee: str | None = None,
         due_date: str | None = None,
         entry_type: str | None = None,
+        significance: list[str] | None = None,
     ) -> dict:
         """Edit an existing entry. Returns updated metadata.
 
@@ -219,6 +223,13 @@ class Store:
 
         if due_date is not None:
             meta["due_date"] = due_date
+
+        if significance is not None:
+            validated_sig = validate_significance(significance)
+            if validated_sig:
+                meta["significance"] = validated_sig
+            else:
+                meta.pop("significance", None)
 
         # Update access metadata
         meta["accessed"] = datetime.now(timezone.utc).isoformat()
@@ -363,7 +374,13 @@ class Store:
 
                     d = days_since(accessed)
                     ac = meta.get("access_count", 1)
-                    score = decay_score(d, ac, config["decay_lambda"])
+                    sig = meta.get("significance")
+                    rc = meta.get("recall_count", 0)
+                    score = decay_score(
+                        d, ac, config["decay_lambda"],
+                        significance=sig,
+                        recall_count=rc,
+                    )
                     meta["decay_score"] = score
 
                     new_tier = classify_tier(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "palaia"
-version = "1.9.0"
+version = "1.10.0"
 description = "Local, cloud-free memory for OpenClaw agents."
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_significance.py
+++ b/tests/test_significance.py
@@ -1,0 +1,321 @@
+"""Tests for significance tagging and retrieval-hit decay (Issue #33)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from palaia.decay import (
+    decay_score,
+    recall_multiplier,
+    significance_multiplier,
+)
+from palaia.entry import (
+    VALID_SIGNIFICANCE,
+    create_entry,
+    parse_entry,
+    serialize_entry,
+    validate_significance,
+)
+
+# ---------- validate_significance ----------
+
+
+class TestValidateSignificance:
+    def test_none_returns_none(self):
+        assert validate_significance(None) is None
+
+    def test_empty_list_returns_none(self):
+        assert validate_significance([]) is None
+
+    def test_single_valid_tag(self):
+        assert validate_significance(["decision"]) == ["decision"]
+
+    def test_multiple_valid_tags(self):
+        result = validate_significance(["decision", "lesson"])
+        assert result == ["decision", "lesson"]
+
+    def test_all_valid_tags(self):
+        result = validate_significance(list(VALID_SIGNIFICANCE))
+        assert set(result) == VALID_SIGNIFICANCE
+
+    def test_invalid_tag_raises(self):
+        with pytest.raises(ValueError, match="Invalid significance tag"):
+            validate_significance(["invalid_tag"])
+
+    def test_mixed_valid_invalid_raises(self):
+        with pytest.raises(ValueError, match="Invalid significance tag"):
+            validate_significance(["decision", "bogus"])
+
+    def test_case_insensitive(self):
+        assert validate_significance(["DECISION"]) == ["decision"]
+        assert validate_significance(["Lesson"]) == ["lesson"]
+
+    def test_strips_whitespace(self):
+        assert validate_significance([" decision "]) == ["decision"]
+
+    def test_dedup(self):
+        result = validate_significance(["decision", "decision", "lesson"])
+        assert result == ["decision", "lesson"]
+
+
+# ---------- significance_multiplier ----------
+
+
+class TestSignificanceMultiplier:
+    def test_none_returns_1(self):
+        assert significance_multiplier(None) == 1.0
+
+    def test_empty_returns_1(self):
+        assert significance_multiplier([]) == 1.0
+
+    def test_decision_returns_3(self):
+        assert significance_multiplier(["decision"]) == 3.0
+
+    def test_lesson_returns_2(self):
+        assert significance_multiplier(["lesson"]) == 2.0
+
+    def test_identity_returns_3(self):
+        assert significance_multiplier(["identity"]) == 3.0
+
+    def test_surprise_returns_1_5(self):
+        assert significance_multiplier(["surprise"]) == 1.5
+
+    def test_human_returns_2_5(self):
+        assert significance_multiplier(["human"]) == 2.5
+
+    def test_multiple_takes_max(self):
+        # decision=3.0, lesson=2.0 → max is 3.0
+        assert significance_multiplier(["decision", "lesson"]) == 3.0
+
+    def test_unknown_tag_returns_1(self):
+        assert significance_multiplier(["unknown"]) == 1.0
+
+
+# ---------- recall_multiplier ----------
+
+
+class TestRecallMultiplier:
+    def test_zero_returns_1(self):
+        assert recall_multiplier(0) == 1.0
+
+    def test_negative_returns_1(self):
+        assert recall_multiplier(-1) == 1.0
+
+    def test_positive_count_increases(self):
+        result = recall_multiplier(5)
+        assert result > 1.0
+
+    def test_higher_count_higher_multiplier(self):
+        m5 = recall_multiplier(5)
+        m50 = recall_multiplier(50)
+        assert m50 > m5
+
+    def test_diminishing_returns(self):
+        # Growth rate slows: gap from 100→1000 smaller than 1→100
+        diff_low = recall_multiplier(100) - recall_multiplier(1)
+        diff_high = recall_multiplier(1000) - recall_multiplier(100)
+        assert diff_low > diff_high
+
+
+# ---------- decay_score with significance/recall ----------
+
+
+class TestDecayScoreWithSignificance:
+    def test_no_significance_same_as_before(self):
+        score_plain = decay_score(10, access_count=1)
+        score_none = decay_score(10, access_count=1, significance=None, recall_count=0)
+        assert score_plain == score_none
+
+    def test_significance_slows_decay(self):
+        score_plain = decay_score(30, access_count=1)
+        score_decision = decay_score(30, access_count=1, significance=["decision"])
+        # Decision tag should make the score higher (slower decay)
+        assert score_decision > score_plain
+
+    def test_recall_count_slows_decay(self):
+        score_plain = decay_score(30, access_count=1)
+        score_recalled = decay_score(30, access_count=1, recall_count=10)
+        assert score_recalled > score_plain
+
+    def test_both_combined(self):
+        score_plain = decay_score(30, access_count=1)
+        score_both = decay_score(30, access_count=1, significance=["decision"], recall_count=10)
+        assert score_both > score_plain
+
+    def test_identity_tag_strong_protection(self):
+        """Identity entries (agent self-model) should be strongly protected."""
+        score_plain = decay_score(60, access_count=1)
+        score_identity = decay_score(60, access_count=1, significance=["identity"])
+        # At 60 days, identity tag should make a big difference
+        assert score_identity > score_plain * 2
+
+
+# ---------- create_entry with significance ----------
+
+
+class TestCreateEntrySignificance:
+    def test_no_significance(self):
+        text = create_entry("test content")
+        meta, _ = parse_entry(text)
+        assert "significance" not in meta
+
+    def test_with_significance(self):
+        text = create_entry("test content", significance=["decision", "lesson"])
+        meta, _ = parse_entry(text)
+        assert meta["significance"] == ["decision", "lesson"]
+
+    def test_invalid_significance_raises(self):
+        with pytest.raises(ValueError):
+            create_entry("test content", significance=["invalid"])
+
+    def test_significance_roundtrip(self):
+        """Significance survives serialize → parse roundtrip."""
+        text = create_entry("test content", significance=["decision", "human"])
+        meta, body = parse_entry(text)
+        assert meta["significance"] == ["decision", "human"]
+
+        # Re-serialize and re-parse
+        text2 = serialize_entry(meta, body)
+        meta2, body2 = parse_entry(text2)
+        assert meta2["significance"] == ["decision", "human"]
+        assert body2 == body
+
+
+# ---------- Store integration ----------
+
+
+class TestStoreSignificance:
+    @pytest.fixture
+    def store(self, tmp_path):
+        from palaia.store import Store
+
+        palaia_dir = tmp_path / ".palaia"
+        palaia_dir.mkdir()
+        for sub in ("hot", "warm", "cold", "wal", "index"):
+            (palaia_dir / sub).mkdir()
+        config = {
+            "agent": "test",
+            "default_scope": "team",
+            "embedding_chain": ["bm25"],
+            "lock_timeout_seconds": 5,
+            "decay_lambda": 0.1,
+            "hot_threshold_days": 7,
+            "warm_threshold_days": 30,
+            "hot_min_score": 0.5,
+            "warm_min_score": 0.1,
+            "wal_retention_days": 7,
+        }
+        (palaia_dir / "config.json").write_text(json.dumps(config))
+        return Store(palaia_dir)
+
+    def test_write_with_significance(self, store):
+        eid = store.write("important decision", significance=["decision"])
+        entry = store.read(eid)
+        assert entry is not None
+        meta, _ = entry
+        assert meta["significance"] == ["decision"]
+
+    def test_write_without_significance(self, store):
+        eid = store.write("normal entry")
+        entry = store.read(eid)
+        assert entry is not None
+        meta, _ = entry
+        assert "significance" not in meta
+
+    def test_edit_add_significance(self, store):
+        eid = store.write("some content")
+        meta = store.edit(eid, significance=["lesson", "human"])
+        assert meta["significance"] == ["lesson", "human"]
+
+    def test_edit_remove_significance(self, store):
+        eid = store.write("content", significance=["decision"])
+        # Edit with empty list should remove significance
+        meta = store.edit(eid, significance=[])
+        assert "significance" not in meta
+
+    def test_gc_significance_aware(self, store):
+        """GC should use significance tags when computing decay scores."""
+        from palaia.entry import parse_entry
+
+        eid = store.write("important", significance=["decision"])
+        # Run GC
+        store.gc()
+        # Read entry back — decay_score should account for significance
+        path = store._find_entry(eid)
+        text = path.read_text()
+        meta, _ = parse_entry(text)
+        # The entry should still be in hot (it's brand new)
+        assert (store.root / "hot" / f"{eid}.md").exists()
+
+
+# ---------- Search integration ----------
+
+
+class TestSearchSignificanceFilter:
+    @pytest.fixture
+    def store(self, tmp_path):
+        from palaia.store import Store
+
+        palaia_dir = tmp_path / ".palaia"
+        palaia_dir.mkdir()
+        for sub in ("hot", "warm", "cold", "wal", "index"):
+            (palaia_dir / sub).mkdir()
+        config = {
+            "agent": "test",
+            "default_scope": "team",
+            "embedding_chain": ["bm25"],
+            "lock_timeout_seconds": 5,
+            "decay_lambda": 0.1,
+            "hot_threshold_days": 7,
+            "warm_threshold_days": 30,
+            "hot_min_score": 0.5,
+            "warm_min_score": 0.1,
+            "wal_retention_days": 7,
+        }
+        (palaia_dir / "config.json").write_text(json.dumps(config))
+        return Store(palaia_dir)
+
+    def test_query_filter_by_significance(self, store):
+        from palaia.search import SearchEngine
+
+        store.write("alpha decision made", significance=["decision"])
+        store.write("beta lesson learned", significance=["lesson"])
+        store.write("gamma no significance")
+
+        engine = SearchEngine(store)
+        results = engine.search("decision lesson", significance="decision")
+        # Should only return the decision entry
+        assert len(results) >= 1
+        for r in results:
+            assert "decision" in r.get("significance", [])
+
+    def test_query_no_significance_filter_returns_all(self, store):
+        from palaia.search import SearchEngine
+
+        store.write("alpha something", significance=["decision"])
+        store.write("alpha something else")
+
+        engine = SearchEngine(store)
+        results = engine.search("alpha something")
+        assert len(results) >= 1  # At least the matching entries
+
+    def test_recall_tracking(self, store):
+        """Query results should increment recall_count and last_recalled."""
+        from palaia.search import SearchEngine
+
+        eid = store.write("recall test content unique")
+        engine = SearchEngine(store)
+
+        # Query twice
+        engine.search("recall test content unique")
+        engine.search("recall test content unique")
+
+        # Read entry and check recall fields
+        path = store._find_entry(eid)
+        text = path.read_text()
+        meta, _ = parse_entry(text)
+        # recall_count should be >= 2 (from the two queries, plus read() calls)
+        assert meta.get("recall_count", 0) >= 2
+        assert "last_recalled" in meta


### PR DESCRIPTION
## Summary

Implements [Issue #33](https://github.com/iret77/palaia/issues/33) — Significance Tagging + Retrieval-Hit Decay.

### Part 1 — Significance Tagging + GC-Awareness
- **`--significance` flag** on `palaia write` and `palaia edit`: comma-separated list from `[decision, surprise, human, lesson, identity]`
- **Frontmatter key** `significance` stored in entry metadata
- **GC decay bonus**: Entries with significance tags decay slower:
  - `decision` / `identity` → 3x slower decay
  - `human` → 2.5x slower
  - `lesson` → 2x slower
  - `surprise` → 1.5x slower
- **`palaia list`** shows Significance column when entries have tags
- **`palaia query --significance <tag>`** filters results by significance tag

### Part 2 — Retrieval-Hit Tracking
- Every query result updates `recall_count` and `last_recalled` in entry frontmatter
- GC decay score modified by `recall_count` — frequently recalled entries decay slower (log-based diminishing returns)
- **`palaia status`** shows Top-5 most-recalled entries
- GC tier-promotion considers recall_count through the unified decay_score

### Technical
- 41 new tests covering all features
- All 684 tests pass (643 existing + 41 new)
- Ruff lint clean
- Version bump: 1.9.0 → 1.10.0
- Backwards compatible: entries without significance/recall_count work as before

Closes #33