### PR TITLE
fix: upgrade docs and version mismatch detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,24 @@ OpenClaw plugin (3 lines in your config):
 
 **Upgrading from v1.x?** Run `palaia doctor --fix` to get the new optimized defaults.
 
+### Upgrading
+
+Palaia consists of **two independent packages** that must be updated separately:
+
+```bash
+# 1. Python CLI (the core tool)
+pip install --upgrade palaia
+# or: uv tool upgrade palaia
+
+# 2. OpenClaw plugin (npm, memory-slot integration)
+npm install -g @byte5ai/palaia@latest
+
+# 3. Verify and fix
+palaia doctor --fix
+```
+
+**Both versions must match exactly.** The npm plugin checks the CLI version at startup and warns on mismatch. If you see a version mismatch warning, update the lagging package.
+
 ## Quick Start
 
 ```bash

--- a/SKILL.md
+++ b/SKILL.md
@@ -1081,12 +1081,12 @@ When sending memos to other agents, use a two-layer approach for reliable delive
 
 ## After Updating Palaia
 
-Palaia has three independent components. Update ALL of them — they version independently:
+Palaia has three independent components. Update ALL of them — **versions must match exactly**:
 
 ```bash
 # 1. Python CLI (the main tool)
 python3 -m pip install --upgrade "palaia[fastembed]"
-# or: uv tool install "palaia[fastembed]"  (always include [fastembed]!)
+# or: uv tool upgrade palaia  (always include [fastembed] if using pip!)
 
 # 2. OpenClaw plugin (memory-slot integration)
 npm install -g @byte5ai/palaia@latest
@@ -1100,6 +1100,8 @@ palaia warmup
 ```
 
 **Why all three?** The pip package is the CLI. The npm package is the OpenClaw plugin that wires Palaia into the memory slot. The SKILL.md (via ClawHub) tells agents how to use Palaia. Updating only one leaves the others stale.
+
+**Version mismatch detection:** The npm plugin automatically checks the CLI version at startup. If the Python CLI version does not match the plugin version, a warning is logged with upgrade instructions. This catches the common mistake of updating only one package.
 
 `palaia doctor` checks your store for compatibility, suggests new features, and handles version stamping. If the installed version differs from the store version, Palaia will warn you on every CLI call until you run `palaia doctor`.
 

--- a/packages/openclaw-plugin/src/hooks.ts
+++ b/packages/openclaw-plugin/src/hooks.ts
@@ -14,7 +14,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
-import { run, runJson, recover, type RunnerOpts, getEmbedServerManager } from "./runner.js";
+import { run, runJson, recover, type RunnerOpts, getEmbedServerManager, getVersionMismatchWarning } from "./runner.js";
 import type { PalaiaPluginConfig, RecallTypeWeights } from "./config.js";
 
 // ============================================================================
@@ -1654,6 +1654,12 @@ export function registerHooks(api: any, config: PalaiaPluginConfig): void {
               turnState.lastInboundMessageId = inbound.messageId;
             }
           }
+        }
+
+        // Version mismatch warning (Issue #99) — surface to agent once per prompt
+        const mismatchWarn = getVersionMismatchWarning();
+        if (mismatchWarn) {
+          nudgeContext += "\n\n## Version Mismatch Warning (Palaia)\n\n" + mismatchWarn;
         }
 
         // Return prependContext + appendSystemContext for recall emoji

--- a/packages/openclaw-plugin/src/runner.ts
+++ b/packages/openclaw-plugin/src/runner.ts
@@ -8,8 +8,10 @@
 
 import { execFile } from "node:child_process";
 import { access, constants } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 
 export interface RunnerOpts {
   /** Working directory for palaia (sets PALAIA_ROOT context) */
@@ -28,6 +30,59 @@ export interface RunResult {
 
 /** Cached binary path after first detection */
 let cachedBinary: string | null = null;
+
+/** Version mismatch warning (set once during first binary detection) */
+let versionMismatchWarning: string | null = null;
+
+/**
+ * Extract semver (Major.Minor.Patch) from a version string.
+ * Strips leading 'v', trailing suffixes like -dev, +build, etc.
+ */
+function parseSemver(raw: string): string | null {
+  const match = raw.trim().match(/v?(\d+\.\d+\.\d+)/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Read the plugin's own version from its package.json.
+ */
+async function getPluginVersion(): Promise<string | null> {
+  try {
+    const pkgPath = join(dirname(fileURLToPath(import.meta.url)), "..", "package.json");
+    const content = await readFile(pkgPath, "utf-8");
+    const pkg = JSON.parse(content);
+    return parseSemver(pkg.version || "");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check CLI version against plugin version. Logs warning on mismatch.
+ * Called once during first binary detection.
+ */
+async function checkVersionMismatch(cliVersionOutput: string): Promise<void> {
+  const cliVersion = parseSemver(cliVersionOutput);
+  const pluginVersion = await getPluginVersion();
+
+  if (!cliVersion || !pluginVersion) return;
+  if (cliVersion === pluginVersion) return;
+
+  versionMismatchWarning =
+    `Palaia CLI version (${cliVersion}) does not match plugin version (${pluginVersion}). ` +
+    `Update with: pip install --upgrade palaia (or: uv tool upgrade palaia), ` +
+    `then run: palaia doctor --fix`;
+
+  console.warn(`[palaia] ${versionMismatchWarning}`);
+}
+
+/**
+ * Get the version mismatch warning, if any.
+ * Returns null if versions match or haven't been checked yet.
+ */
+export function getVersionMismatchWarning(): string | null {
+  return versionMismatchWarning;
+}
 
 /**
  * Detect the palaia binary location.
@@ -62,6 +117,7 @@ export async function detectBinary(
     });
     if (result.exitCode === 0) {
       cachedBinary = "palaia";
+      await checkVersionMismatch(result.stdout);
       return "palaia";
     }
   } catch {
@@ -72,6 +128,11 @@ export async function detectBinary(
   const pipxPath = join(homedir(), ".local", "bin", "palaia");
   try {
     await access(pipxPath, constants.X_OK);
+    // Get version for mismatch check
+    const pipxResult = await execCommand(pipxPath, ["--version"], { timeoutMs: 5000 });
+    if (pipxResult.exitCode === 0) {
+      await checkVersionMismatch(pipxResult.stdout);
+    }
     cachedBinary = pipxPath;
     return pipxPath;
   } catch {
@@ -85,6 +146,7 @@ export async function detectBinary(
     });
     if (result.exitCode === 0) {
       cachedBinary = "python3";
+      await checkVersionMismatch(result.stdout);
       return "python3"; // Will need `-m palaia` prefix
     }
   } catch {

--- a/packages/openclaw-plugin/tests/runner.test.ts
+++ b/packages/openclaw-plugin/tests/runner.test.ts
@@ -10,13 +10,14 @@ vi.mock("node:child_process", () => ({
   execFile: vi.fn(),
 }));
 
-// Mock fs/promises for access checks
+// Mock fs/promises for access checks and readFile
 vi.mock("node:fs/promises", () => ({
   access: vi.fn().mockRejectedValue(new Error("ENOENT")),
+  readFile: vi.fn().mockRejectedValue(new Error("ENOENT")),
   constants: { X_OK: 1 },
 }));
 
-import { detectBinary, run, runJson, recover, resetCache } from "../src/runner.js";
+import { detectBinary, run, runJson, recover, resetCache, getVersionMismatchWarning } from "../src/runner.js";
 
 const mockExecFile = vi.mocked(execFile);
 
@@ -115,6 +116,12 @@ describe("runner", () => {
       const result = await recover({ binaryPath: "palaia" });
       expect(result.replayed).toBe(0);
       expect(result.errors).toBe(1);
+    });
+  });
+
+  describe("getVersionMismatchWarning", () => {
+    it("returns null before any binary detection", () => {
+      expect(getVersionMismatchWarning()).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Changes

### Issue #98: Upgrade documentation
- **README.md**: Added dedicated 'Upgrading' section documenting that both Python CLI (`pip install --upgrade palaia`) and npm plugin (`npm install -g @byte5ai/palaia@latest`) must be updated separately
- **SKILL.md**: Added version mismatch detection note to 'After Updating Palaia' section, emphasized that versions must match exactly

### Issue #99: Version mismatch detection in npm plugin
- **runner.ts**: After the existing `palaia --version` call during binary detection, the CLI version is parsed (semver only: Major.Minor.Patch) and compared against the plugin's own package.json version. On mismatch, a warning is logged to console and stored for agent-facing nudges.
- **hooks.ts**: The mismatch warning is surfaced to agents as a nudge in the `before_prompt_build` hook context, so agents can inform users about the version discrepancy.
- **runner.test.ts**: Added test coverage for `getVersionMismatchWarning` export.

### Warning text on mismatch
> Palaia CLI version (X) does not match plugin version (Y). Update with: pip install --upgrade palaia (or: uv tool upgrade palaia), then run: palaia doctor --fix

### Tests
- Python: 836 passed
- TypeScript (vitest): 160 passed (4 test files)

Fixes #98, Fixes #99