### PR TITLE
docs: update repo docs for v2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## v2.5 — 2026-04-02
+
+### New Features
+- **Agent Isolation Mode** — `--isolated` flag on `palaia init` enables scope-based memory filtering between agents. Agents can operate with isolated memory scopes via `scopeVisibility` and `captureScope` in `priorities.json`. Pre-configured profiles: Isolated Worker, Orchestrator, Lean Worker.
+- **Modern CLI Design System** — Borderless column-aligned tables replace box-drawing. ANSI colors with full TTY detection. Respects `NO_COLOR` and `FORCE_COLOR` env vars. Unicode symbols (✓ ✗ ⚠ ℹ → ▸). Zero new dependencies.
+- **Backup-Restore Fix** — Auto-detect orphaned entries on disk (e.g. after restoring a backup). `palaia doctor --fix` rebuilds metadata index from flat files. Migration auto-triggers on `Store()` init when entries are orphaned but database is empty.
+
+### Infrastructure
+- CI stabilization: flaky concurrent write tests marked `xfail(strict=False)`.
+- Matrix `fail-fast: false` for complete test coverage across Python 3.9–3.12.
+- AGENTS.md and pre-push hook for branch protection.
+
+### Migration from v2.4
+- `pip install --upgrade palaia` — no manual steps required.
+- Existing stores work as-is. New CLI output is purely cosmetic.
+
+---
+
+## v2.4 — 2026-03-28
+
+### New Features
+- **Session Continuity** — Automatic briefings and summaries across agent sessions. Agents resume where they left off.
+- **Privacy Markers** — Fine-grained control over which parts of conversations get captured.
+- **Recency Boost** — Recent entries rank higher in recall queries.
+- **Progressive Disclosure** — CLI nudges adapt based on agent experience level.
+- **`palaia skill` strips install section** — Saves context window tokens when agents read SKILL.md.
+
+### Improvements
+- OpenClaw v2026.3.28 compatibility (updated plugin SDK types).
+- Codex review fixes: 8 findings addressed, 20 new tests.
+- README restructured for better first impression.
+
+### Migration from v2.2
+- `pip install --upgrade palaia && palaia doctor --fix` — handles everything automatically.
+
+---
+
 ## v2.2.0 — 2026-03-26
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Palaia gives your agents a persistent, searchable knowledge store. They save wha
 | **Zero-config local setup** | SQLite with native SIMD vector search — no separate database process |
 | **Works everywhere via MCP** | One memory store for OpenClaw, Claude Desktop, Cursor, and more |
 | **Multi-agent ready** | Private, team, and public scopes — agents see what they should |
+| **Agent isolation** | `--isolated` mode for strict per-agent memory boundaries |
 | **Crash-safe by default** | SQLite WAL mode survives power loss, kills, OOM |
 | **Fast** | Embed server keeps model in RAM — CLI queries ~1.5s, MCP/Plugin <500ms |
 | **Scales when needed** | Swap to PostgreSQL + pgvector for distributed teams, no code changes |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -151,7 +151,14 @@ Show system health, entry counts, backend type, vector search method, embed-serv
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--fix` | — | Show guided fix instructions |
+| `--fix` | — | Auto-fix detected issues |
+
+Detects and fixes:
+- Missing or broken embedding chains
+- Orphaned entries on disk with empty database (e.g. after backup restore)
+- Stale embedding indexes
+- Version mismatches
+- Unread memos
 
 ### `palaia upgrade`
 

--- a/docs/multi-agent.md
+++ b/docs/multi-agent.md
@@ -103,6 +103,44 @@ When a new agent joins an existing workspace:
 
 Agents without palaia will not auto-capture conversations, not benefit from shared knowledge, and may duplicate work.
 
+## Agent Isolation Mode
+
+For strict memory separation between agents, use isolation mode:
+
+```bash
+palaia init --agent alice --isolated
+```
+
+This configures the agent with:
+- **`captureScope: private`** — all captured entries are private by default
+- **`scopeVisibility: own`** — agent only sees its own entries in recall
+
+### Pre-configured Profiles
+
+Configure via `priorities.json`:
+
+| Profile | `captureScope` | `scopeVisibility` | Use case |
+|---------|---------------|-------------------|----------|
+| **Isolated Worker** | `private` | `own` | Default for `--isolated`. Agent works alone. |
+| **Orchestrator** | `team` | `all` | Coordinator that reads all, writes team-visible. |
+| **Lean Worker** | `private` | `team` | Reads team knowledge, captures privately. |
+
+### Example: Mixed team
+
+```bash
+# Worker agents — isolated
+palaia init --agent coder --isolated
+palaia init --agent reviewer --isolated
+
+# Orchestrator — sees everything
+palaia init --agent lead
+# Then in priorities.json: set scopeVisibility: "all" for lead
+```
+
+Isolation mode is purely additive — it doesn't affect existing entries or other agents.
+
+---
+
 ## Project-Level Isolation
 
 Entries can be scoped to projects:


### PR DESCRIPTION
## Summary
- Add v2.4 and v2.5 entries to CHANGELOG.md
- Add agent isolation to README feature table
- Document Agent Isolation Mode in docs/multi-agent.md
- Expand `palaia doctor --fix` description in docs/cli-reference.md

Docs-only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)